### PR TITLE
[hotfix] Use explicit FileSourceSplit type.

### DIFF
--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -174,7 +174,7 @@ re-created in the `BulkFormat#restoreReader(Configuration, FileSourceSplit)` met
 
 A `SimpleStreamFormat` can be turned into a `BulkFormat` by wrapping it in a `StreamFormatAdapter`:
 ```java
-BulkFormat<SomePojo, ?> bulkFormat = 
+BulkFormat<SomePojo, FileSourceSplit> bulkFormat = 
         new StreamFormatAdapter<>(CsvReaderFormat.forPojo(SomePojo.class));
 ```
 


### PR DESCRIPTION
The wildcard is OK for initialization, but further usage will require the explicit type, so this is a more consistent way to describe the construction.