### PR TITLE
Add smallserial and apply changes after refactoring pgjdbc/pgjdbc#1194

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<postgres.version>42.2.10</postgres.version>
+		<postgres.version>42.3.3</postgres.version>
 		<oracle.version>19.3.0.0</oracle.version>
 	</properties>
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
@@ -49,6 +49,8 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
     // float <=> float8
     // boolean <=> bool
     // decimal <=> numeric
+    private static final String PG_SMALLSERIAL = "smallserial";
+    private static final String PG_SMALLSERIAL_ARRAY = "_smallserial";
     private static final String PG_SERIAL = "serial";
     private static final String PG_BIGSERIAL = "bigserial";
     private static final String PG_BYTEA = "bytea";
@@ -102,7 +104,9 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
             case PG_BYTEA_ARRAY:
                 return DataTypes.ARRAY(DataTypes.BYTES());
             case PG_SMALLINT:
+            case PG_SMALLSERIAL:
                 return DataTypes.SMALLINT();
+            case PG_SMALLSERIAL_ARRAY:
             case PG_SMALLINT_ARRAY:
                 return DataTypes.ARRAY(DataTypes.SMALLINT());
             case PG_INTEGER:

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
@@ -91,7 +91,10 @@ public class PostgresRowConverter extends AbstractJdbcRowConverter {
                 final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
                 for (int i = 0; i < in.length; i++) {
                     array[i] =
-                            elementConverter.deserialize(((PGobject) in[i]).getValue().getBytes());
+                            elementConverter.deserialize(
+                                    in[i] instanceof byte[]
+                                            ? in[i]
+                                            : ((PGobject) in[i]).getValue().getBytes());
                 }
                 return new GenericArrayData(array);
             };

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -154,7 +154,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
         assertEquals(
                 "[+I["
                         + "[1, 2, 3], "
-                        + "[[92, 120, 51, 50], [92, 120, 51, 51], [92, 120, 51, 52]], "
+                        + "[[50], [51], [52]], "
                         + "[3, 4, 5], "
                         + "[4, 5, 6], "
                         + "[5.5, 6.6, 7.7], "


### PR DESCRIPTION
## What is the purpose of the change

The PR adds support for Postgres `smallserial` and `_smallserial` type which were added in 42.2.17 at https://github.com/pgjdbc/pgjdbc/pull/899
and changes expected output for `bytea[]` as it was changed at https://github.com/pgjdbc/pgjdbc/pull/1194

## Verifying this change

This change is already covered by existing tests, such as 
*org.apache.flink.connector.jdbc.catalog.PostgresCatalogITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
