### PR TITLE
[FLINK-25926][Connectors][JDBC] PG's bytea[] now uses primitive arrays

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
@@ -50,7 +50,6 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
     // boolean <=> bool
     // decimal <=> numeric
     private static final String PG_SMALLSERIAL = "smallserial";
-    private static final String PG_SMALLSERIAL_ARRAY = "_smallserial";
     private static final String PG_SERIAL = "serial";
     private static final String PG_BIGSERIAL = "bigserial";
     private static final String PG_BYTEA = "bytea";
@@ -106,7 +105,6 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
             case PG_SMALLINT:
             case PG_SMALLSERIAL:
                 return DataTypes.SMALLINT();
-            case PG_SMALLSERIAL_ARRAY:
             case PG_SMALLINT_ARRAY:
                 return DataTypes.ARRAY(DataTypes.SMALLINT());
             case PG_INTEGER:

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
@@ -22,13 +22,11 @@ import org.apache.flink.connector.jdbc.converter.AbstractJdbcRowConverter;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.PGobject;
 
 import java.lang.reflect.Array;
 
@@ -78,41 +76,20 @@ public class PostgresRowConverter extends AbstractJdbcRowConverter {
     }
 
     private JdbcDeserializationConverter createPostgresArrayConverter(ArrayType arrayType) {
-        // PG's bytea[] is wrapped in PGobject, rather than primitive byte arrays
-        if (arrayType.getElementType().is(LogicalTypeFamily.BINARY_STRING)) {
-            final Class<?> elementClass =
-                    LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
-            final JdbcDeserializationConverter elementConverter =
-                    createNullableInternalConverter(arrayType.getElementType());
-
-            return val -> {
-                PgArray pgArray = (PgArray) val;
-                Object[] in = (Object[]) pgArray.getArray();
-                final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
-                for (int i = 0; i < in.length; i++) {
-                    array[i] =
-                            elementConverter.deserialize(
-                                    in[i] instanceof byte[]
-                                            ? in[i]
-                                            : ((PGobject) in[i]).getValue().getBytes());
-                }
-                return new GenericArrayData(array);
-            };
-        } else {
-            final Class<?> elementClass =
-                    LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
-            final JdbcDeserializationConverter elementConverter =
-                    createNullableInternalConverter(arrayType.getElementType());
-            return val -> {
-                PgArray pgArray = (PgArray) val;
-                Object[] in = (Object[]) pgArray.getArray();
-                final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
-                for (int i = 0; i < in.length; i++) {
-                    array[i] = elementConverter.deserialize(in[i]);
-                }
-                return new GenericArrayData(array);
-            };
-        }
+        // Since PGJDBC 42.2.15 (https://github.com/pgjdbc/pgjdbc/pull/1194) is wrapped in primitive byte arrays
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+        final JdbcDeserializationConverter elementConverter =
+                createNullableInternalConverter(arrayType.getElementType());
+        return val -> {
+            PgArray pgArray = (PgArray) val;
+            Object[] in = (Object[]) pgArray.getArray();
+            final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
+            for (int i = 0; i < in.length; i++) {
+                array[i] = elementConverter.deserialize(in[i]);
+            }
+            return new GenericArrayData(array);
+        };
     }
 
     // Have its own method so that Postgres can support primitives that super class doesn't support


### PR DESCRIPTION
The PR with addressing feedback

1.  Remove erroneously created in first PR `_smallserial` since it is not supported by pgjdbc
2. Since new pgjdbc driver handles `byte[]` without `PGObject` then it could be done in same way as for other types in _org.apache.flink.connector.jdbc.internal.converter.PostgresRowConverter#createPostgresArrayConverter_